### PR TITLE
devices.yml: Add DSC-RX1

### DIFF
--- a/devices.yml
+++ b/devices.yml
@@ -25,6 +25,9 @@ DSC-QX100:
 DSC-RX0:
   gen: 3
   model: 0x61020010
+DSC-RX1:
+  gen: 2
+  model: 0x22020020
 DSC-RX1R:
   gen: 2
   model: 0x22020024


### PR DESCRIPTION
I run `guess_firmware` on my DSC-RX1:
```
Getting device info
Model name: DSC-RX1

Trying 100 firmware images
Firmware update error: Invalid version
Success: Found matching file: gen2_0x22020020_0.dat
```

Can you please tell me how to generate the `Sony-PMCA-RE\updatershell\fdat\gen2\DSC-RX1.hdr`. (I would prefer to get a step by step description over you doing it for me).
Unfortunately there is no firmware update available for this camera :-(.

My end goal is to unlock the non Japanese languages on my camera.